### PR TITLE
Mark archived cards as state:closed

### DIFF
--- a/import-issues.py
+++ b/import-issues.py
@@ -225,6 +225,8 @@ class Card(object):
             self.card_data['url'],
             self.card_data['desc']
         )
+        if self.card_data['closed'] == True:
+            state['state'] = 'closed' 
 
         state = dict(
             list(state.items()) +


### PR DESCRIPTION
Thanks for this great tool.  It has saved me a lot of time! 

I made a change that others might find useful: I imported a Trello board with a large number of archived cards which were left  as state:open. Running the script again with this change marked them all closed.  The API docs imply you can't create issues as state:closed (I've not had a chance to try), so running the script twice may be required, but at least it gets the job done. 
